### PR TITLE
Fix countdown notification interval

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -32,34 +32,43 @@ end)
 
 minetest.register_globalstep(function(dtime)
 	local currGameTime = minetest.get_gametime()
-	
+
+	--Check for inactivity once every CHECK_INTERVAL seconds
+	checkTimer = checkTimer + dtime
+
+	local checkNow = checkTimer >= CHECK_INTERVAL
+	if checkNow then
+		checkTimer = checkTimer - CHECK_INTERVAL
+	end
+
 	--Loop through each player in players
-	for playerName,_ in pairs(players) do
+	for playerName, info in pairs(players) do
 		local player = minetest.get_player_by_name(playerName)
 		if player then
-		
-			--Check for inactivity once every CHECK_INTERVAL seconds
-			checkTimer = checkTimer + dtime
-			if checkTimer > CHECK_INTERVAL then
-				checkTimer = 0
-				
+			--Check if this player is doing an action
+			for _, keyPressed in pairs(player:get_player_control()) do
+				if keyPressed then
+					info["lastAction"] = currGameTime
+				end
+			end
+
+			if checkNow then
 				--Kick player if he/she has been inactive for longer than MAX_INACTIVE_TIME seconds
-				if players[playerName]["lastAction"] + MAX_INACTIVE_TIME < currGameTime then 
+				if info["lastAction"] + MAX_INACTIVE_TIME < currGameTime then
 					minetest.kick_player(playerName, "Kicked for inactivity")
 				end
-				
+
 				--Warn player if he/she has less than WARN_TIME seconds to move or be kicked
-				if players[playerName]["lastAction"] + MAX_INACTIVE_TIME - WARN_TIME < currGameTime then
-					minetest.chat_send_player(playerName, "Warning, you have " .. tostring(players[playerName]["lastAction"] + MAX_INACTIVE_TIME - currGameTime) .. " seconds to move or be kicked")
+				if info["lastAction"] + MAX_INACTIVE_TIME - WARN_TIME < currGameTime then
+					minetest.chat_send_player(playerName,
+						minetest.colorize("#FF8C00", "Warning, you have " ..
+						tostring(info["lastAction"] + MAX_INACTIVE_TIME - currGameTime + 1) ..
+						" seconds to move or be kicked"))
 				end
 			end
-			
-			--Check if this player is doing an action
-			for _,keyPressed in pairs(player:get_player_control()) do
-				if keyPressed then
-					players[playerName]["lastAction"] = currGameTime
-				end
-			end
+		else
+			-- Clean up garbage
+			players[playerName] = nil
 		end
 	end
 end)


### PR DESCRIPTION
Previously `dtime` was added to the counter per player, which is an incorrect behaviour. This results in much faster countdowns and player notifications multiple times per second.

* Only check per interval once
* Shorten `players[playerName]` to table reference `info`

Opened a PR here because also other servers use this mod, not just [ruben's CTF](https://github.com/rubenwardy/capturetheflag/pull/155).